### PR TITLE
refactor - reimplement `system.react` and `system.reactLatest` operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 * refactor - rename parameter `skipFirst*` to `skipInitial*`
+* refactor - reimplement `system.react` and `system.reactLatest` operators
 
 ## [0.1.0-beta.5] - 2020-08-06
 

--- a/lib/src/types/optional.dart
+++ b/lib/src/types/optional.dart
@@ -1,9 +1,0 @@
-
-/// `Optional` is the same as nullable except it can handle nested cases like `Optional<Optional<int>>`.
-abstract class Optional<T> {}
-
-class OptionalNone<T> implements Optional<T> {}
-class OptionalValue<T> implements Optional<T> {
-  OptionalValue(this.value);
-  final T value;
-}

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -1,6 +1,7 @@
 
 /// Describe if a and b are equal
 typedef AreEqual<T> = bool Function(T it1, T it2);
+bool defaultAreEqual<T>(T it1, T it2) => it1 == it2;
 
 /// Describe how state update when event come
 typedef Reduce<State, Event> = State Function(State state, Event event);

--- a/test/systems/system_react_latest_test.dart
+++ b/test/systems/system_react_latest_test.dart
@@ -108,4 +108,111 @@ void main() {
     expect(disposedVersions, [1, 2]);
   });
 
+  test('System.reactLatest.skipInitialValue', () async {
+
+    int valueInvoked = 0;
+    int effectInvoked = 0;
+    int effectVersion = 0;
+    List<String> stateParameters = [];
+    List<String> valueParameters = [];
+    List<int> disposedVersions = [];
+
+    final it = await testSystem<String, String>(
+      system: createTestSystem(initialState: 'a')
+        .reactLatest<String>(
+          skipInitialValue: true,
+          value: (state) {
+            stateParameters.add(state);
+            valueInvoked += 1;
+            return state.substring(state.length - 1);
+          },
+          effect: (value, dispatch) {
+            valueParameters.add(value);
+            effectInvoked += 1;
+            if (value == 'b') {
+              effectVersion += 1;
+              delayed(1, () => dispatch('i'));
+              final version = effectVersion;
+              return Dispose(() {
+                disposedVersions.add(version);
+              });
+            }
+          },
+        ),
+      events: (dispatch, dispose) => [
+        dispatch(0, 'a'),
+        dispatch(0, 'b'),
+        dispatch(10, 'c'),
+        dispatch(10, 'a'),
+        dispatch(20, 'b'),
+        dispatch(20, 'c'),
+        dispose(30),
+        dispatch(40, 'a'),
+        dispatch(50, 'b'),
+      ],
+      awaitMilliseconds: 60,
+    );
+
+    expect(it.events, [
+      null,
+      'a',
+      'b',
+      'i',
+      'c',
+      'a',
+      'b',
+      'c',
+    ]);
+
+    expect(it.states, [
+      'a',
+      'a|a',
+      'a|a|b',
+      'a|a|b|i',
+      'a|a|b|i|c',
+      'a|a|b|i|c|a',
+      'a|a|b|i|c|a|b',
+      'a|a|b|i|c|a|b|c',
+    ]);
+
+    expect(it.oldStates, [
+      null,
+      'a',
+      'a|a',
+      'a|a|b',
+      'a|a|b|i',
+      'a|a|b|i|c',
+      'a|a|b|i|c|a',
+      'a|a|b|i|c|a|b',
+    ]);
+
+    expect(it.isDisposed, true);
+
+    expect(stateParameters, [
+      'a',
+      'a|a',
+      'a|a|b',
+      'a|a|b|i',
+      'a|a|b|i|c',
+      'a|a|b|i|c|a',
+      'a|a|b|i|c|a|b',
+      'a|a|b|i|c|a|b|c',
+    ]);
+
+    expect(valueParameters, [
+      'b',
+      'i',
+      'c',
+      'a',
+      'b',
+      'c',
+    ]);
+    
+    expect(valueInvoked, 8);
+    expect(effectInvoked, 6);
+    expect(effectVersion, 2);
+
+    expect(disposedVersions, [1, 2]);
+  });
+
 }

--- a/test/systems/system_react_test.dart
+++ b/test/systems/system_react_test.dart
@@ -107,4 +107,109 @@ void main() {
     expect(effectInvoked, 8);
     expect(dispatchInvoked, 2);
   });
+
+  test('System.react.skipInitialValue', () async {
+
+    int valueInvoked = 0;
+    int effectInvoked = 0;
+    int dispatchInvoked = 0;
+    List<String> stateParameters = [];
+    List<String> valueParameters = [];
+
+    final it = await testSystem<String, String>(
+      system: createTestSystem(initialState: 'a')
+        .react<String>(
+          skipInitialValue: true,
+          value: (state) {
+            stateParameters.add(state);
+            valueInvoked += 1;
+            return state.substring(state.length - 1);
+          },
+          effect: (value, dispatch) {
+            valueParameters.add(value);
+            effectInvoked += 1;
+            if (value == 'b') {
+              dispatch('i');
+              dispatchInvoked += 1;
+            }
+          },
+        ),
+      events: (dispatch, dispose) => [
+        dispatch(0, 'a'),
+        dispatch(0, 'b'),
+        dispatch(10, 'c'),
+        dispatch(10, 'a'),
+        dispatch(20, 'b'),
+        dispatch(20, 'c'),
+        dispose(30),
+        dispatch(40, 'a'),
+        dispatch(50, 'b'),
+      ],
+      awaitMilliseconds: 60,
+    );
+
+    expect(it.events, [
+      null,
+      'a',
+      'b',
+      'i',
+      'c',
+      'a',
+      'b',
+      'c',
+      'i',
+    ]);
+
+    expect(it.states, [
+      'a',
+      'a|a',
+      'a|a|b',
+      'a|a|b|i',
+      'a|a|b|i|c',
+      'a|a|b|i|c|a',
+      'a|a|b|i|c|a|b',
+      'a|a|b|i|c|a|b|c',
+      'a|a|b|i|c|a|b|c|i',
+    ]);
+
+    expect(it.oldStates, [
+      null,
+      'a',
+      'a|a',
+      'a|a|b',
+      'a|a|b|i',
+      'a|a|b|i|c',
+      'a|a|b|i|c|a',
+      'a|a|b|i|c|a|b',
+      'a|a|b|i|c|a|b|c',
+    ]);
+
+    expect(it.isDisposed, true);
+
+    expect(stateParameters, [
+      'a',
+      'a|a',
+      'a|a|b',
+      'a|a|b|i',
+      'a|a|b|i|c',
+      'a|a|b|i|c|a',
+      'a|a|b|i|c|a|b',
+      'a|a|b|i|c|a|b|c',
+      'a|a|b|i|c|a|b|c|i',
+    ]);
+
+    expect(valueParameters, [
+      'b',
+      'i',
+      'c',
+      'a',
+      'b',
+      'c',
+      'i',
+    ]);
+
+    expect(valueInvoked, 9);
+    expect(effectInvoked, 7);
+    expect(dispatchInvoked, 2);
+  });
 }


### PR DESCRIPTION
Reimplement `system.react` and `system.reactLatest` operators for improving code readability.