### PR TITLE
expose `system.runWithContext`'s `dispose` callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * refactor - rename `EventInterceptor` to `InterceptorWithContext` [#96](https://github.com/LoveCommunity/love.dart/issues/96)
 * refactor - add `interceptor` to system [#96](https://github.com/LoveCommunity/love.dart/issues/96)
 * refactor - reimplement `eventInterceptor` for composability [#96](https://github.com/LoveCommunity/love.dart/issues/96)
+* refactor - expose `system.runWithContext`'s `dispose` callback for disposing context [#98](https://github.com/LoveCommunity/love.dart/issues/98)
 
 ## [0.1.0-beta.6] - 2020-09-22
 

--- a/lib/src/systems/filter_event_on_system.dart
+++ b/lib/src/systems/filter_event_on_system.dart
@@ -232,10 +232,10 @@ extension FilterEventOperators<State, Event> on System<State, Event> {
         );
         return Dispose(() {
           isDisposed = true;
-          dispose?.call(context);
           sourceDispose();
         });
       },
+      dispose: dispose,
     );
   }
 }

--- a/test/systems/system_run_with_context_test.dart
+++ b/test/systems/system_run_with_context_test.dart
@@ -20,15 +20,14 @@ void main() {
           },
           run: (context, run, nextReduce, nextEffect, nextInterceptor) {
             context.invoked += 1;
-            final dispose = run(
+            return run(
               reduce: nextReduce,
               effect: nextEffect,
               interceptor: nextInterceptor,
             );
-            return Dispose(() {
-              context.isDisposed = true;
-              dispose();
-            });
+          },
+          dispose: (context) {
+            context.isDisposed = true;
           },
         ),
       events: (dispatch, dispose) => [
@@ -180,6 +179,9 @@ void main() {
               interceptor: nextInterceptor,
             );
           },
+          dispose: (context) {
+            context.isDisposed = true;
+          },
         ),
       events: (dispatch, dispose) => [
         dispatch(0, 'b'),
@@ -249,6 +251,7 @@ void main() {
     ]);
 
     expect(_context!.invoked, 6);
+    expect(_context!.isDisposed, true);
   });
 
   test('System.runWithContext.interceptor', () async {
@@ -275,6 +278,9 @@ void main() {
                 context.invoked += 1;
               }),
             );
+          },
+          dispose: (context) {
+            context.isDisposed = true;
           },
         ),
       events: (dispatch, dispose) => [
@@ -320,5 +326,6 @@ void main() {
     ]);
 
     expect(_context!.invoked, 5);
+    expect(_context!.isDisposed, true);
   });
 }


### PR DESCRIPTION
According to the principle of who creates and disposes, `system.runWithContext` should expose a `dispose` callback for disposing context:

```dart
system.runWithContext(
  createContext: () { ... }, // create context here
  run: (...) { ...  },
  dispose: (context) { ... }  //  <- add this callback for disposing context 
)
...
```