### PR TITLE
refactor - add `effectForwarder.dispose` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * refactor - add `interceptor` to system [#96](https://github.com/LoveCommunity/love.dart/issues/96)
 * refactor - reimplement `eventInterceptor` for composability [#96](https://github.com/LoveCommunity/love.dart/issues/96)
 * refactor - expose `system.runWithContext`'s `dispose` callback for disposing context [#98](https://github.com/LoveCommunity/love.dart/issues/98)
+* refactor - add `effectForwarder.dispose` method [#99](https://github.com/LoveCommunity/love.dart/issues/98)
 
 ## [0.1.0-beta.6] - 2020-09-22
 

--- a/test/forwarders/effect_forwarder_test.dart
+++ b/test/forwarders/effect_forwarder_test.dart
@@ -182,4 +182,15 @@ void main() {
     dispose3();
   });
 
+  test('EffectForwarder.add.afterDisposed', () {
+    
+    final forwarder = EffectForwarder<String, String>()
+      ..dispose();
+    
+    expect(
+      () => forwarder.add(effect: (_, __, ___, ____) { }), 
+      throwsStateError
+    );
+  });
+
 }


### PR DESCRIPTION
Add `effectForwarder.dispose` method to dispose it explicity.