### PR TITLE
CI - only trigger CI tests on push and pull request with main branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: [main]
+    paths-ignore: ['**.md']
+  pull_request:
+    branches: [main]
+    paths-ignore: ['**.md']
 
 jobs:
   build:


### PR DESCRIPTION
CI - only trigger CI tests on push and pull request with main branch.
thanks to `rxdart`.